### PR TITLE
Bugfix/powershell progress bug

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -255,12 +255,19 @@ class BaseAction(Action):
         """
         creds = self.resolve_creds(**kwargs)
         tport = self.resolve_transport(creds['connect'], **kwargs)
-        powershell = ''
+
+        """Has ProgressPreference=false because if the
+        attempts to load modules that progress is forwarded
+        into the stderr and causes the commands to fail.
+        There is an open pull request to pywinrm:
+        https://github.com/diyan/pywinrm/issues/169
+        """
+        powershell = '$ProgressPreference=false\n'
         cmdlet_args = kwargs['args'] if 'args' in kwargs else ''
         output_ps = self.resolve_output_ps(**kwargs)
 
         if 'username' in creds['cmdlet'] and 'password' in creds['cmdlet']:
-            powershell = ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
+            powershell += ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                           "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                           "{0} -Credential $admincreds {1}"
                           "").format(cmdlet,
@@ -268,7 +275,7 @@ class BaseAction(Action):
                                      creds['cmdlet']['username'],
                                      creds['cmdlet']['password'])
         else:
-            powershell = '{0} {1}'.format(cmdlet, cmdlet_args)
+            powershell += '{0} {1}'.format(cmdlet, cmdlet_args)
 
         # add output formatters to the powershell code
         powershell = output_ps.format(powershell)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -256,9 +256,10 @@ class BaseAction(Action):
         creds = self.resolve_creds(**kwargs)
         tport = self.resolve_transport(creds['connect'], **kwargs)
 
-        """Has ProgressPreference=false because if the
-        attempts to load modules that progress is forwarded
-        into the stderr and causes the commands to fail.
+        """Added ProgressPreference=false as first line
+        because if powershell attempts to load any modules
+        the progress of the module loading is then forwarded
+        into stderr and causes stackstorm to fail the call.
         There is an open pull request to pywinrm:
         https://github.com/diyan/pywinrm/issues/169
         """

--- a/tests/test_action_lib_baseaction.py
+++ b/tests/test_action_lib_baseaction.py
@@ -271,7 +271,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',
@@ -295,7 +295,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',
@@ -319,7 +319,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
+        powershell = ("$ProgressPreference=false\n"
+                      "$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                       "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                       "{0} -Credential $admincreds {1}"
                       "").format(cmdlet,
@@ -350,7 +351,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         powershell = self.get_output_ps_code('json').format(powershell)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -411,7 +412,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
         powershell = self.get_output_ps_code('json').format(powershell)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -438,7 +439,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
+        powershell = ("$ProgressPreference=false\n"
+                      "$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                       "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                       "{0} -Credential $admincreds {1}"
                       "").format(cmdlet,

--- a/tests/test_action_lib_baseaction.py
+++ b/tests/test_action_lib_baseaction.py
@@ -271,7 +271,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = ("$ProgressPreference=false\n"
+                      "{0} {1}").format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',
@@ -295,7 +296,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = ("$ProgressPreference=false\n"
+                      "{0} {1}").format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
                                       hostname='abc',


### PR DESCRIPTION
Added $ProgressPreference=false\n to the beggining of all powershell lines to prevent the progress of loading modules from entering stderr and failing run tasks, until the PR diyan/pywinrm#169 gets merged by pywinrm.


