### PR TITLE
Bugfix/progress preference

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.1.2
+
+- Fixed `$ProgressPreference=false` by setting it to `$ProgressPreference = 'SilentlyContinue'`
+
+  Contributed by Nick Maludy (Encore Technologies)
+
 ## v0.1.1
 
 - In new versions of Powershell if you load a module some text is output into 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -256,14 +256,14 @@ class BaseAction(Action):
         creds = self.resolve_creds(**kwargs)
         tport = self.resolve_transport(creds['connect'], **kwargs)
 
-        """Added ProgressPreference=false as first line
+        """Added $ProgressPreference = 'SilentlyContinue' as first line
         because if powershell attempts to load any modules
         the progress of the module loading is then forwarded
         into stderr and causes stackstorm to fail the call.
         There is an open pull request to pywinrm:
         https://github.com/diyan/pywinrm/issues/169
         """
-        powershell = '$ProgressPreference=false\n'
+        powershell = "$ProgressPreference = 'SilentlyContinue';\n"
         cmdlet_args = kwargs['args'] if 'args' in kwargs else ''
         output_ps = self.resolve_output_ps(**kwargs)
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -9,6 +9,6 @@ keywords:
     - active
     - directory
     - ad
-version: 0.1.1
+version: 0.1.2
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_baseaction.py
+++ b/tests/test_action_lib_baseaction.py
@@ -271,7 +271,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$ProgressPreference=false\n"
+        powershell = ("$ProgressPreference = 'SilentlyContinue';\n"
                       "{0} {1}").format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -296,7 +296,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$ProgressPreference=false\n"
+        powershell = ("$ProgressPreference = 'SilentlyContinue';\n"
                       "{0} {1}").format(cmdlet, cmdlet_args)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -321,7 +321,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$ProgressPreference=false\n"
+        powershell = ("$ProgressPreference = 'SilentlyContinue';\n"
                       "$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                       "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                       "{0} -Credential $admincreds {1}"
@@ -353,7 +353,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference = 'SilentlyContinue';\n{0} {1}".format(cmdlet,
+                                                                                 cmdlet_args)
         powershell = self.get_output_ps_code('json').format(powershell)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -414,7 +415,8 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = "$ProgressPreference=false\n{0} {1}".format(cmdlet, cmdlet_args)
+        powershell = "$ProgressPreference = 'SilentlyContinue';\n{0} {1}".format(cmdlet,
+                                                                                 cmdlet_args)
         powershell = self.get_output_ps_code('json').format(powershell)
         result = action.run_ad_cmdlet(cmdlet,
                                       credential_name='base',
@@ -441,7 +443,7 @@ class TestActionLibBaseAction(ActiveDirectoryBaseActionTestCase):
 
         cmdlet = 'Test-Cmdlet'
         cmdlet_args = ''
-        powershell = ("$ProgressPreference=false\n"
+        powershell = ("$ProgressPreference = 'SilentlyContinue';\n"
                       "$securepass = ConvertTo-SecureString \"{3}\" -AsPlainText -Force;\n"
                       "$admincreds = New-Object System.Management.Automation.PSCredential(\"{2}\", $securepass);\n"  # noqa
                       "{0} -Credential $admincreds {1}"


### PR DESCRIPTION
When setting `$ProgressPreference=false` we were receiving errors.

This change sets it to the value `$ProgressPreference = 'SilentlyContinue'` as documented in the following:

https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_preference_variables?view=powershell-5.1
https://docs.microsoft.com/en-us/dotnet/api/system.management.automation.actionpreference?view=powershellsdk-1.1.0
http://www.jasonhelmick.com/2010/11/06/suppressing-the-powershell-progress-bar-2/